### PR TITLE
Added base class for KeyPointDetectionDataset

### DIFF
--- a/coco_lib/keypointdetection.py
+++ b/coco_lib/keypointdetection.py
@@ -5,7 +5,7 @@ from dataclasses_json import dataclass_json
 
 from .bases import Dataset
 from .common import Info, Image, License
-from .objectdetection import ObjectDetectionAnnotation, ObjectDetectionCategory
+from .objectdetection import ObjectDetectionAnnotation, ObjectDetectionCategory, ObjectDetectionDataset
 
 
 @dataclass_json
@@ -24,6 +24,6 @@ class KeypointDetectionCategory(ObjectDetectionCategory):
 
 @dataclass_json
 @dataclass
-class KeypointDetectionDataset(Dataset):
+class KeypointDetectionDataset(ObjectDetectionDataset):
     annotations: List[KeypointDetectionAnnotation]
     categories: List[KeypointDetectionCategory]


### PR DESCRIPTION
As mentioned in #1 there are some attributes missing for `KeyPointDetectionDataset`. This is because the base class was not set to `ObjectDetectionDataset`.